### PR TITLE
Allow user to set his credentials

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const wrappedFetch = function (url, params = {}) {
         headerDict(params.headers),
         defaultHeaders
     );
-    params.credentials = 'same-origin';
+    params.credentials = params.credentials || 'same-origin';
 
     if (params.body
         && typeof params.body !== 'string'


### PR DESCRIPTION
In some cases users might want to set the credentials to any of the other options. Be it for security reasons:
https://fetch.spec.whatwg.org/#cors-protocol-and-credentials
Or he might want to share cookies between different services:
http://stackoverflow.com/questions/3342140/cross-domain-cookies