### PR TITLE
Replace babel-preset-latest with babel-preset-env

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,19 +11,17 @@ var wrappedFetch = function wrappedFetch(url) {
     params.credentials = 'same-origin';
 
     if (params.body && typeof params.body !== 'string' && !(params.body instanceof FormData)) {
-        (function () {
 
-            var body = new FormData();
-            Object.entries(params.body).forEach(function (_ref) {
-                var _ref2 = _slicedToArray(_ref, 2),
-                    k = _ref2[0],
-                    v = _ref2[1];
+        var body = new FormData();
+        Object.entries(params.body).forEach(function (_ref) {
+            var _ref2 = _slicedToArray(_ref, 2),
+                k = _ref2[0],
+                v = _ref2[1];
 
-                return body.append(k, v);
-            });
+            return body.append(k, v);
+        });
 
-            params.body = body;
-        })();
+        params.body = body;
     }
 
     return fetch(url, params);
@@ -39,9 +37,12 @@ var headerDict = function headerDict(headers) {
 
         try {
             for (var _iterator = headers.entries()[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-                var _step$value = _slicedToArray(_step.value, 2),
-                    key = _step$value[0],
-                    value = _step$value[1];
+                var _ref3 = _step.value;
+
+                var _ref4 = _slicedToArray(_ref3, 2);
+
+                var key = _ref4[0];
+                var value = _ref4[1];
 
                 dict[key] = value;
             }

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "homepage": "https://github.com/Swizec/better-fetch#readme",
   "devDependencies": {
     "babel-cli": "^6.18.0",
-    "babel-preset-latest": "^6.16.0"
+    "babel-preset-env": "^1.5.1"
   },
   "babel": {
     "presets": [
-      "latest"
+      "env"
     ]
   }
 }


### PR DESCRIPTION
While lamenting the spotty support for ES6 in modern tooling, I stumbled upon your [article on making a wrapper for fetch in ES6](https://swizec.com/blog/fun-surprise-uglifyjs-cant-es6/swizec/7272). Thank you for sharing your experiences.

I thought you might be interested in the fact that `babel-preset-latest` appears [to be deprecated](https://babeljs.io/docs/plugins/preset-latest/) in favor of [`babel-preset-env`](https://babeljs.io/docs/plugins/preset-env/). The babel docs say that the "env" preset with no options acts just like the "latest" preset.

Feel free to do whatever you want with this PR. I just wanted to try and give you a little help keeping one of your projects up-to-date 😉👍 

> **Note:** The transpiled output is *different*, but it might actually be better. Full disclosure, I did not test the newly transpiled code...